### PR TITLE
Feature/#157705335/clear spaces

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,7 +72,5 @@ end
 
 gem 'minesweeper_2pl', git: 'https://github.com/shibani/minesweeper_2pl', branch: 'master'
 
-# gem 'minesweeper_2pl', path: '~/Documents/projects/minesweeper_2pl'
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shibani/minesweeper_2pl
-  revision: 2fe872c6f90a6b635914c89aff3790794c95bd1e
+  revision: b9cf94ac173eff9118dec84f796e4b393095dc00
   branch: master
   specs:
     minesweeper_2pl (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shibani/minesweeper_2pl
-  revision: b9cf94ac173eff9118dec84f796e4b393095dc00
+  revision: 94c3dc61bd299ddf506f56a338fa3c090b1da0f3
   branch: master
   specs:
     minesweeper_2pl (0.1.0)

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -2,68 +2,68 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 * {
-	margin:0;
-	padding:0;
+  margin:0;
+  padding:0;
 }
 
 body{
-	font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
-	position:relative;
-	color: #a9a9a9;
-	font-size:14px;
-	margin: 0 auto 40px auto;
+  font-family: Arial, 'Helvetica Neue', Helvetica, sans-serif;
+  position:relative;
+  color: #a9a9a9;
+  font-size:14px;
+  margin: 0 auto 40px auto;
   text-align:center;
 }
 
 a{
-	text-decoration:none;
-	color: #e60000 !important;
-	font-weight:bold;
+  text-decoration:none;
+  color: #e60000 !important;
+  font-weight:bold;
 }
 
 u{
-	text-decoration:none;
+  text-decoration:none;
 }
 
 a:link, a:hover, a:visited, a:active{
-	text-decoration:none;
+  text-decoration:none;
 }
 
 h1, h2, h3, h4, h5, h6, p, li{
-	margin:0;
-	padding:0;
-	font-weight:normal;
+  margin:0;
+  padding:0;
+  font-weight:normal;
 }
 
 ul{
-	list-style-type: none;
+  list-style-type: none;
 }
 
 li{}
 
 img, link, input, button{
-	border:0;
-	outline:0
+  border:0;
+  outline:0
 }
 
 .left{
-	float:left;
+  float:left;
 }
 
 .right{
-	float:right;
+  float:right;
 }
 
 .clear{
-	clear:both;
+  clear:both;
 }
 
 .show{
-	display:block;
+  display:block;
 }
 
 .hide{
-	display:none
+  display:none
 }
 
 textarea {
@@ -88,7 +88,7 @@ section.container{
   }
 
   .form-container{
-    width:auto;
+    width:420px;
     margin: 0 auto 30px auto;
 
     .row{
@@ -104,9 +104,36 @@ section.container{
       justify-content:center;
       align-items:center;
 
-      form, input.cell-submit{
-        width:100%;
-        height:100%;
+      form{
+          width:100%;
+          height:100%;
+
+          input.cell-submit{
+            width:100%;
+            height:100%;
+            font-size:11px;
+          }
+
+          input.cell-submit[value="🚩"]{
+          //input.cell-submit[value="U+1F6a9"]{
+            font-size:20px;
+          }
+
+          input.cell-submit[value="💣"]{
+          //input.cell-submit[value="U+1F4a3"]{
+            font-size:20px;
+          }
+
+          input.cell-submit[value="U+1F3c6"]{
+          //input.cell-submit[value="🏆"]{
+            font-size:20px;
+          }
+
+          input.cell-submit[value="X"], input.cell-submit[value="X "]{
+            font-size:12px;
+            font-weight:bold;
+            color:#000;
+          }
       }
     }
   }

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -97,7 +97,7 @@ section.container{
       justify-content:center;
     }
     .cell{
-      border: 1px solid #a9a9a9;
+      //border: 1px solid #f3f3f3;
       width:40px;
       height:35px;
       display:flex;
@@ -112,20 +112,30 @@ section.container{
             width:100%;
             height:100%;
             font-size:11px;
+            background-color: #f0f0f0;
+            border-left: 1px solid #fff;
+            border-top: 1px solid #fff;
+            border-right: 1px solid #e3e3e3;
+            border-bottom: 1px solid #e3e3e3;
+
+            &.active{
+              background-color: #e8e8e8;
+              border-left: 1px solid #d3d3d3;
+              border-top: 1px solid #d3d3d3;
+              border-right: 1px solid #f0f0f0;
+              border-bottom: 1px solid #d3d3d3;
+            }
           }
 
           input.cell-submit[value="🚩"]{
-          //input.cell-submit[value="U+1F6a9"]{
             font-size:20px;
           }
 
           input.cell-submit[value="💣"]{
-          //input.cell-submit[value="U+1F4a3"]{
             font-size:20px;
           }
 
-          input.cell-submit[value="U+1F3c6"]{
-          //input.cell-submit[value="🏆"]{
+          input.cell-submit[value="🏆"]{
             font-size:20px;
           }
 

--- a/app/controllers/concerns/helpers.rb
+++ b/app/controllers/concerns/helpers.rb
@@ -14,18 +14,18 @@ module Helpers
   end
 
   def board_config(game, positions)
-    game.set_positions(positions)
     bomb_array = bomb_positions_in_string(positions)
     game.set_bomb_positions(bomb_array)
+    game.set_positions(positions)
   end
 
-  # def convert_params_to_move(move, content, rowsize)
-  #   [
-  #     (move % rowsize).to_i,
-  #     (move / rowsize).to_i,
-  #     content == 'F' ? 'flag' : 'move'
-  #   ]
-  # end
+  def convert_params_to_move(move, content, rowsize)
+    [
+      (move % rowsize).to_i,
+      (move / rowsize).to_i,
+      content == 'F' ? 'flag' : 'move'
+    ]
+  end
 
   def update_board_with_move(game, move)
     game.mark_move_on_board(move)
@@ -39,15 +39,48 @@ module Helpers
     game_positions.each_index.select { |i| game_positions[i].include? 'B' }
   end
 
+  def find_revealed(cells_array)
+    cells_array.each_index.select{ |i| cells_array[i].status == 'revealed' }
+  end
+
+  def find_flags(cells_array)
+    cells_array.each_index.select{ |i| cells_array[i].flag == 'F' }
+  end
+
+  def update_revealed_status(game, revealed_positions)
+    unless revealed_positions.nil? || revealed_positions.empty?
+      revealed = revealed_positions.split(',').map(&:to_i)
+      game.set_cell_status(revealed)
+    end
+  end
+
+  def update_flag_status(game, flag_positions)
+    unless flag_positions.nil? || flag_positions.empty?
+      flags = flag_positions.split(',').map(&:to_i)
+      flags.each do |flag|
+        game.board_positions[flag].update_flag unless game.board_positions[flag].status == 'revealed'
+      end
+    end
+  end
+
+  def update_bombs_to_revealed(game)
+    game.board_positions.each do |position|
+      position.update_cell_status if position.content == 'B'
+    end
+  end
+
   def build_board_view(game, row_size, show_bombs=nil)
     game.board_formatter.show_bombs = show_bombs
     board_array = game.board_formatter.format_board_with_emoji(game.board)
-    game.board_positions(&:values).each_slice(row_size).map.with_index do |row, row_index|
+    game.board_positions.each_slice(row_size).map.with_index do |row, row_index|
       row.map.with_index do |cell, cell_index|
         cell_position = row_index * row_size + cell_index
-        content = cell
+        content = board_array[cell_position]
         submit_btn = board_array[cell_position]
-        [cell_position, content, submit_btn]
+        cell_class = game.board_positions[cell_position].status == 'revealed' ? 'cell-submit active' : 'cell-submit'
+        form_status =
+        game.board_positions[cell_position].status == 'revealed' ? true : false
+        [cell_position, content, submit_btn, cell_class, form_status]
       end
     end
   end

--- a/app/controllers/concerns/helpers.rb
+++ b/app/controllers/concerns/helpers.rb
@@ -19,6 +19,14 @@ module Helpers
     game.set_bomb_positions(bomb_array)
   end
 
+  # def convert_params_to_move(move, content, rowsize)
+  #   [
+  #     (move % rowsize).to_i,
+  #     (move / rowsize).to_i,
+  #     content == 'F' ? 'flag' : 'move'
+  #   ]
+  # end
+
   def update_board_with_move(game, move)
     game.mark_move_on_board(move)
   end
@@ -34,7 +42,7 @@ module Helpers
   def build_board_view(game, row_size, show_bombs=nil)
     game.board_formatter.show_bombs = show_bombs
     board_array = game.board_formatter.format_board_with_emoji(game.board)
-    game.board_positions.each_slice(row_size).map.with_index do |row, row_index|
+    game.board_positions(&:values).each_slice(row_size).map.with_index do |row, row_index|
       row.map.with_index do |cell, cell_index|
         cell_position = row_index * row_size + cell_index
         content = cell

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -7,7 +7,7 @@ class SiteController < ApplicationController
     game = create_game(10, 10)
     ui = create_interface
     @header = display_header(ui)
-    positions = game.board_positions
+    positions = game.board_positions.map{ |el| el.content }
     @positions_to_string = positions.join(',')
     @rowsize = game.row_size
     @board = build_board_view(game, @rowsize)
@@ -17,6 +17,7 @@ class SiteController < ApplicationController
     game_positions = params[:positions].split(',')
     @rowsize = params[:rowsize].to_i
     user_move = params[:index].to_i
+    content = params[:content]
     game = create_game(@rowsize, 0)
     ui = create_interface
     board_config(game, game_positions)
@@ -27,6 +28,9 @@ class SiteController < ApplicationController
     else
       update_board_with_move(game, user_move)
     end
+    # move = convert_params_to_move(user_move, content, @rowsize)
+    # game.place_move(move)
+
     game.game_over = true if game.is_won?
     if game.game_over
       if game.is_won?

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -28,6 +28,9 @@ class SiteController < ApplicationController
     update_revealed_status(game, revealed_positions)
     move = convert_params_to_move(user_move, content, @rowsize)
     game.place_move(move)
+    logger.debug '*******'
+    logger.debug game.bomb_positions
+    logger.debug '*******'
     update_flag_status(game, flag_positions)
     game.game_over = true if game.is_won?
 

--- a/app/views/site/home.html.erb
+++ b/app/views/site/home.html.erb
@@ -7,13 +7,14 @@
         <div class="row">
         <% row.each.with_index do |cell, j| %>
           <div class='cell <%= "cell_#{i*@rowsize + j}" %>'>
-            <% cell_class = ((i*@rowsize + j > 30) && (i*@rowsize + j < 35)) ? 'cell-submit active' : 'cell-submit'%>
             <%= form_with url: site_home_path do |f|%>
             <%= f.hidden_field :content, value: cell[1] %>
             <%= f.hidden_field :index, value: cell[0] %>
             <%= f.hidden_field :positions, value: @positions_to_string %>
             <%= f.hidden_field :rowsize, value: @rowsize %>
-            <%= f.submit cell[2], name: 'btnSubmit', class: cell_class, id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: @disable_submit %>
+            <%= f.hidden_field :revealed, value: @positions_to_reveal %>
+            <%= f.hidden_field :flags, value: @flags %>
+            <%= f.submit cell[2], name: 'btnSubmit', class: cell[3], id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: cell[4] || @disable_submit%>
             <% end %>
           </div><!-- end cell -->
         <% end %>

--- a/app/views/site/home.html.erb
+++ b/app/views/site/home.html.erb
@@ -7,12 +7,13 @@
         <div class="row">
         <% row.each.with_index do |cell, j| %>
           <div class='cell <%= "cell_#{i*@rowsize + j}" %>'>
+            <% cell_class = ((i*@rowsize + j > 30) && (i*@rowsize + j < 35)) ? 'cell-submit active' : 'cell-submit'%>
             <%= form_with url: site_home_path do |f|%>
             <%= f.hidden_field :content, value: cell[1] %>
             <%= f.hidden_field :index, value: cell[0] %>
             <%= f.hidden_field :positions, value: @positions_to_string %>
             <%= f.hidden_field :rowsize, value: @rowsize %>
-            <%= f.submit cell[2], name: 'btnSubmit', class: "cell-submit", id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: @disable_submit %>
+            <%= f.submit cell[2], name: 'btnSubmit', class: cell_class, id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: @disable_submit %>
             <% end %>
           </div><!-- end cell -->
         <% end %>

--- a/spec/concerns/site_controller_helper_spec.rb
+++ b/spec/concerns/site_controller_helper_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe SiteController, type: :controller do
 
     expect(game.board_values).to eq(expected_array)
   end
-
+  
   it 'can set the boards bomb positions' do
-    positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
+    positions = 'B,1, , ,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
     SiteController.board_config(game, positions)
 
     expect(game.bomb_positions).to match_array([0,8])

--- a/spec/concerns/site_controller_helper_spec.rb
+++ b/spec/concerns/site_controller_helper_spec.rb
@@ -22,19 +22,19 @@ RSpec.describe SiteController, type: :controller do
   end
 
   it 'can return the bomb positions in the game' do
-    positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
+    positions = 'B,1,0,0,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
     result = SiteController.bomb_positions_in_string(positions)
 
     expect(result).to match_array([0,8])
   end
 
-  it 'can set the boards positions' do
-    positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
-    SiteController.board_config(game, positions)
-    expected_array = ["B","1","X","X","0","0","1","2","B","1","2","2","0","0","0","0"]
-
-    expect(game.board_positions).to match_array(expected_array)
-  end
+  # it 'can set the boards positions' do
+  #   positions = 'B,1,0,0,2,2,0,0,B,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0'.split(",")
+  #   SiteController.board_config(game, positions)
+  #   expected_array = ['B',1,0,0,2,2,0,0,'B',1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0]
+  #
+  #   expect(game.board_values).to match_array(expected_array)
+  # end
 
   it 'can set the boards bomb positions' do
     positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
@@ -46,29 +46,23 @@ RSpec.describe SiteController, type: :controller do
   it 'can update the board with a move' do
     SiteController.update_board_with_move(game, 13)
 
-    expect(game.board_positions[13]).to eq('X')
+    expect(game.board_positions[13].status).to eq('revealed')
   end
 
   it 'can update the board with a flag' do
     SiteController.update_board_with_flag(game, 20)
 
-    expect(game.board_positions[20]).to eq('F')
+    expect(game.board_positions[20].flag).to eq('F')
   end
 
   it 'can build an array for the board view' do
-    positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0,1,2,B,1F,0,X,X,0,0'.split(",")
+    positions = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
     SiteController.board_config(game, positions)
     result = SiteController.build_board_view(game, game.row_size)
 
-    expected_array = [
-      [[0, 'B', '  '], [1, '1', '1 '], [2, 'X', 'X '], [3, 'X', 'X '], [4, '0', '0 ']],
-      [[5, '0', '0 '], [6, '1', '1 '], [7, '2', '2 '], [8, 'B', '  '], [9, '1', '1 ']],
-      [[10, '2', '2 '], [11, '2', '2 '], [12, '0', '0 '], [13, '0', '0 '], [14, '0', '0 ']],
-      [[15, '0', '0 '], [16, '1', '1 '], [17, '2', '2 '], [18, 'B', '  '], [19, '1F', "\u{1f6a9}"]],
-      [[20, '0', '0 '], [21, 'X', 'X '], [22, 'X', 'X '], [23, '0', '0 '], [24, '0', '0 ']]
-    ]
 
-    expect(result).to match_array(expected_array)
+    expected_array = [0,'  ', '  ', 'cell-submit', false]
+    assert_equal(result[0][0], expected_array)
   end
 
   it 'can return a flag' do
@@ -101,5 +95,23 @@ RSpec.describe SiteController, type: :controller do
     result = SiteController.move_is_a_bomb(params)
 
     expect(result).to be(true)
+  end
+
+  it 'can convert params to a user move' do
+  end
+
+  it 'can find the revealed cells if given the board' do
+  end
+
+  it 'can find the flags if given the board' do
+  end
+
+  it 'can update the revealed status of cells on the board' do
+  end
+
+  it 'can update the flag status of cells on the board' do
+  end
+
+  it 'can update the bomb positions to be revealed' do
   end
 end

--- a/spec/concerns/site_controller_helper_spec.rb
+++ b/spec/concerns/site_controller_helper_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe SiteController, type: :controller do
     expect(result).to match_array([0,8])
   end
 
-  # it 'can set the boards positions' do
-  #   positions = 'B,1,0,0,2,2,0,0,B,1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0'.split(",")
-  #   SiteController.board_config(game, positions)
-  #   expected_array = ['B',1,0,0,2,2,0,0,'B',1,0,0,1,0,0,0,0,0,0,0,0,0,0,0,0]
-  #
-  #   expect(game.board_values).to match_array(expected_array)
-  # end
+  it 'can set the boards positions' do
+    positions = 'B, , , , , , , ,B, , , , , , , , , , , , , , , , '.split(",")
+    SiteController.board_config(game, positions)
+    expected_array = ['B', 1, 1, 1, 1, 1, 1, 1, 'B', 1, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
+    expect(game.board_values).to eq(expected_array)
+  end
 
   it 'can set the boards bomb positions' do
     positions = 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
@@ -98,20 +98,61 @@ RSpec.describe SiteController, type: :controller do
   end
 
   it 'can convert params to a user move' do
-  end
+    move = 15
+    result = SiteController.convert_params_to_move(move, 'F', 5)
 
-  it 'can find the revealed cells if given the board' do
-  end
-
-  it 'can find the flags if given the board' do
+    expect(result).to eq([0,3,'flag'])
   end
 
   it 'can update the revealed status of cells on the board' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    to_reveal = '10,11,12,13,14'
+    update_revealed_status(game, to_reveal)
+
+    expect(game.board_positions[10].status).to eq('revealed')
+  end
+
+  it 'can find the revealed cells if given the board' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    to_reveal = '10,11,12,13,14'
+    update_revealed_status(game, to_reveal)
+    result = find_revealed(game.board_positions)
+
+    expect(result).to eq([10,11,12,13,14])
   end
 
   it 'can update the flag status of cells on the board' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    to_flag = '10,11,12,13,14'
+    update_flag_status(game, to_flag)
+
+    expect(game.board_positions[10].flag).to eq('F')
+  end
+
+  it 'can find the flagged cells if given the board' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    to_flag = '10,11,12,13,14'
+    update_flag_status(game, to_flag)
+    result = find_flags(game.board_positions)
+
+    expect(result).to eq([10,11,12,13,14])
   end
 
   it 'can update the bomb positions to be revealed' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    update_bombs_to_revealed(game)
+    bomb_positions = bomb_positions_in_string(cells_array)
+
+    expect(game.board_positions[bomb_positions.first].status).to eq('revealed')
   end
 end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -76,6 +76,8 @@ RSpec.describe SiteController, type: :controller do
 
     params6 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,19,20,21,22,24', 'flags': '0,8,18,23'}
 
+    params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X', 'revealed': '10,11,12'}
+
     let (:game) {SiteController.create_game(5,5)}
 
     it 'returns a 200 OK status' do
@@ -148,15 +150,6 @@ RSpec.describe SiteController, type: :controller do
       post :update, params: params6
 
       expect(assigns(:positions_to_reveal)).to include('18')
-    end
-
-    xit 'can update the flags' do
-      post :update, params: params5
-
-      expect(assigns(:board)[0][0][1]).to eq("\u{1f6a9}")
-    end
-
-    it 'can update the bomb positions to be revealed' do
     end
   end
 end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -62,17 +62,19 @@ RSpec.describe SiteController, type: :controller do
   end
 
   describe 'update' do
-    params = { 'content': 'X', 'index': '1', 'rowsize'=>'4', 'positions': ' ,B, , , , , , , , , , , , , , '}
+    params = { 'content': '  ', 'index': '1', 'rowsize'=>'4', 'positions': ' ,B, , , , , , , , , , , , , , ', 'revealed': '1'}
 
     params1 = { 'content': '0', 'index': '1', 'rowsize'=>'4', 'positions': ' , , , , , , , , , , , , , , , '}
 
     params2 = { 'content': '2', 'index': '11', 'rowsize'=>'4', 'positions': 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params3 = { 'content': 'B', 'index': '0', 'rowsize'=>'4', 'positions': 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
+    params3 = { 'content': 'B', 'index': '0', 'rowsize'=>'4', 'positions': 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0', 'revealed': '0'}
 
     params4 = { 'content': 'F', 'index': '1', 'rowsize'=>'4', 'positions': 'BF,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'BF,B,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X'}
+    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'BF,B,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X', 'revealed': '1'}
+
+    params6 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,19,20,21,22,24', 'flags': '0,8,18,23'}
 
     let (:game) {SiteController.create_game(5,5)}
 
@@ -88,30 +90,21 @@ RSpec.describe SiteController, type: :controller do
 
     it 'marks the move if position is not a bomb' do
       post :update, params: params2
-      row_array = [
-        [[0, 'B', '  '], [1, '1', '1 '], [2, 'X', 'X '], [3, 'X', 'X ']],
-        [[4, '0', '0 '], [5, '0', '0 '], [6, '1', '1 '], [7, '2', '2 ']],
-        [[8, 'B', '  '], [9, '1', '1 '], [10, '2', '2 '], [11, 'X', 'X ']],
-        [[12, '0', '0 '], [13, '0', '0 '], [14, '0', '0 '], [15, '0', '0 ']]
-      ]
-      expect(assigns(:board)).to eq(row_array)
+      array = [11, '0 ', '0 ', 'cell-submit active', true]
+      expect(assigns(:board)[2][3]).to eq(array)
     end
 
     it 'marks the move if position is not a bomb v2' do
       post :update, params: params2
 
-      expect(assigns(:positions_to_string)).to eq('B,1,X,X,0,0,1,2,B,1,2,X,0,0,0,0')
+      expect(assigns(:positions_to_string)).to eq('B,1,0,0,2,2,0,0,B,1,0,0,1,1,0,0')
     end
 
     it 'shows the bombs if move is a bomb' do
       post :update, params: params3
-      row_array = [
-        [[0, 'B', "\u{1f4a3}"], [1, '1', '1 '], [2, 'X', 'X '], [3, 'X', 'X ']],
-        [[4, '0', '0 '], [5, '0', '0 '], [6, '1', '1 '], [7, '2', '2 ']],
-        [[8, 'B', "\u{1f4a3}"], [9, '1', '1 '], [10, '2', '2 '], [11, '2', '2 ']],
-        [[12, '0', '0 '], [13, '0', '0 '], [14, '0', '0 '], [15, '0', '0 ']]
-      ]
-      expect(assigns(:board)).to eq(row_array)
+
+      cell_array = [0, "\u{1f4a3}", "\u{1f4a3}", 'cell-submit active', true]
+      expect(assigns(:board)[0][0]).to eq(cell_array)
     end
 
     it 'shows the game over message' do
@@ -122,32 +115,48 @@ RSpec.describe SiteController, type: :controller do
 
     it 'can post a flag as a move' do
       post :update, params: params4
-      row_array = [
-        [[0, 'BF', "\u{1f6a9}"], [1, '1F', "\u{1f6a9}"], [2, 'X', 'X '], [3, 'X', 'X ']],
-        [[4, '0', '0 '], [5, '0', '0 '], [6, '1', '1 '], [7, '2', '2 ']],
-        [[8, 'B', '  '], [9, '1', '1 '], [10, '2', '2 '], [11, '2', '2 ']],
-        [[12, '0', '0 '], [13, '0', '0 '], [14, '0', '0 '], [15, '0', '0 ']]
-      ]
-      expect(assigns(:board)).to eq(row_array)
+      cell_array = [1, "\u{1f6a9}", "\u{1f6a9}", 'cell-submit', false]
+
+      expect(assigns(:board)[0][1]).to eq(cell_array)
     end
 
-    it 'does not mark the position with a flag if position is a user_move' do
-      post :update, params: params4
-      row_array = [
-        [[0, 'BF', "\u{1f6a9}"], [1, '1F', "\u{1f6a9}"], [2, 'X', 'X '], [3, 'X', 'X ']],
-        [[4, '0', '0 '], [5, '0', '0 '], [6, '1', '1 '], [7, '2', '2 ']],
-        [[8, 'B', '  '], [9, '1', '1 '], [10, '2', '2 '], [11, '2', '2 ']],
-        [[12, '0', '0 '], [13, '0', '0 '], [14, '0', '0 '], [15, '0', '0 ']]
-      ]
-      expect(assigns(:board)).to eq(row_array)
+    it 'does not mark the position with a flag if position is revealed' do
+      post :update, params: params5
+      cell_array = [ 1, '  ', '  ', 'cell-submit active', true]
+      expect(assigns(:board)[0][1]).to eq(cell_array)
     end
 
     it 'can check if the game is won' do
-      positions = 'BF,BF,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X'.split(",")
-      SiteController.board_config(game, positions)
-      post :update, params: params5
+      post :update, params: params6
 
       expect(assigns(:header)).to eq('Game over! You win!')
+    end
+
+    it 'can update the revealed positions' do
+      post :update, params: params6
+
+      expect(assigns(:board)[2][0][3]).to include('active')
+    end
+
+    it 'can send the revealed positions to the board' do
+      post :update, params: params6
+
+      expect(assigns(:positions_to_reveal)).to include('10')
+    end
+
+    it 'can send the flags to the board' do
+      post :update, params: params6
+
+      expect(assigns(:positions_to_reveal)).to include('18')
+    end
+
+    xit 'can update the flags' do
+      post :update, params: params5
+
+      expect(assigns(:board)[0][0][1]).to eq("\u{1f6a9}")
+    end
+
+    it 'can update the bomb positions to be revealed' do
     end
   end
 end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -66,17 +66,17 @@ RSpec.describe SiteController, type: :controller do
 
     params1 = { 'content': '0', 'index': '1', 'rowsize'=>'4', 'positions': ' , , , , , , , , , , , , , , , '}
 
-    params2 = { 'content': '2', 'index': '11', 'rowsize'=>'4', 'positions': 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
+    params2 = { 'content': '2', 'index': '11', 'rowsize'=>'4', 'positions': 'B,1, , ,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params3 = { 'content': 'B', 'index': '0', 'rowsize'=>'4', 'positions': 'B,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0', 'revealed': '0'}
+    params3 = { 'content': 'B', 'index': '0', 'rowsize'=>'4', 'positions': 'B,1, , ,0,0,1,2,B,1,2,2,0,0,0,0', 'revealed': '0'}
 
     params4 = { 'content': 'F', 'index': '1', 'rowsize'=>'4', 'positions': 'BF,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'BF,B,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X', 'revealed': '1'}
+    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'BF,B, , , , , , ,BF, , , , , , , , , ,BF, , , , ,BF, ', 'revealed': '1'}
 
     params6 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,19,20,21,22,24', 'flags': '0,8,18,23'}
 
-    params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B,X,X,X,X,X,X,BF,X,X,X,X,X,X,X,X,X,BF,X,X,X,X,BF,X', 'revealed': '10,11,12'}
+    params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B, , , , , , ,BF, , , , , , , , , ,BF, , , , ,BF, ', 'revealed': '10,11,12'}
 
     let (:game) {SiteController.create_game(5,5)}
 


### PR DESCRIPTION
When the first square I click contains a bomb
Then I should not lose the game. Instead, clear the bomb and treat the square as if it was empty

Reassign the bomb

if square is a value reveal the value

When user clicks on a square and values are revealed
Then the background color of the square should change, indicating it has been revealed.
User should not be able to click on it after that.