### PR TITLE
Improvement/#157887870/fix flag behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shibani/minesweeper_2pl
-  revision: 94c3dc61bd299ddf506f56a338fa3c090b1da0f3
+  revision: caecebfb9844eb6e677f8f8dc3d062cbadd8ab54
   branch: master
   specs:
     minesweeper_2pl (0.1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/shibani/minesweeper_2pl
-  revision: caecebfb9844eb6e677f8f8dc3d062cbadd8ab54
+  revision: fd5d97f3c2fad0571a81b76341b9265a9e52c54b
   branch: master
   specs:
     minesweeper_2pl (0.1.0)

--- a/app/assets/stylesheets/site.scss
+++ b/app/assets/stylesheets/site.scss
@@ -97,12 +97,23 @@ section.container{
       justify-content:center;
     }
     .cell{
-      //border: 1px solid #f3f3f3;
       width:40px;
       height:35px;
       display:flex;
       justify-content:center;
       align-items:center;
+
+      &.guessed{
+        position:relative;
+        &:before{
+          content: "🚩";
+          position: absolute;
+          width: 100%;
+          height: 100%;
+          top: 4px;
+          left: -2px;
+        }
+      }
 
       form{
           width:100%;
@@ -137,12 +148,6 @@ section.container{
 
           input.cell-submit[value="🏆"]{
             font-size:20px;
-          }
-
-          input.cell-submit[value="X"], input.cell-submit[value="X "]{
-            font-size:12px;
-            font-weight:bold;
-            color:#000;
           }
       }
     }

--- a/app/controllers/concerns/helpers.rb
+++ b/app/controllers/concerns/helpers.rb
@@ -27,20 +27,12 @@ module Helpers
     ]
   end
 
-  def update_board_with_move(game, move)
-    game.mark_move_on_board(move)
-  end
-
-  def update_board_with_flag(game, move)
-    game.mark_flag_on_board(move)
-  end
-
   def bomb_positions_in_string(game_positions)
     game_positions.each_index.select { |i| game_positions[i].include? 'B' }
   end
 
   def find_revealed(cells_array)
-    cells_array.each_index.select{ |i| cells_array[i].status == 'revealed' }
+    cells_array.each_index.select{ |i| cells_array[i].status == 'revealed'}
   end
 
   def find_flags(cells_array)
@@ -48,24 +40,22 @@ module Helpers
   end
 
   def update_revealed_status(game, revealed_positions)
-    unless revealed_positions.nil? || revealed_positions.empty?
-      revealed = revealed_positions.split(',').map(&:to_i)
-      game.set_cell_status(revealed)
-    end
+    return if (revealed_positions.nil? || revealed_positions.empty?)
+    revealed = revealed_positions.split(',').map(&:to_i)
+    game.set_cell_status(revealed)
   end
 
   def update_flag_status(game, flag_positions)
-    unless flag_positions.nil? || flag_positions.empty?
-      flags = flag_positions.split(',').map(&:to_i)
-      flags.each do |flag|
-        game.board_positions[flag].update_flag unless game.board_positions[flag].status == 'revealed'
-      end
+    return if (flag_positions.nil? || flag_positions.empty?)
+    flags = flag_positions.split(',').map(&:to_i)
+    flags.each do |flag|
+      game.board_positions[flag].update_flag
     end
   end
 
   def update_bombs_to_revealed(game)
     game.board_positions.each do |position|
-      position.update_cell_status if position.content == 'B'
+      position.update_cell_status if position.content.include? 'B'
     end
   end
 
@@ -75,12 +65,12 @@ module Helpers
     game.board_positions.each_slice(row_size).map.with_index do |row, row_index|
       row.map.with_index do |cell, cell_index|
         cell_position = row_index * row_size + cell_index
-        content = board_array[cell_position]
-        submit_btn = board_array[cell_position]
-        cell_class = game.board_positions[cell_position].status == 'revealed' ? 'cell-submit active' : 'cell-submit'
-        form_status =
-        game.board_positions[cell_position].status == 'revealed' ? true : false
-        [cell_position, content, submit_btn, cell_class, form_status]
+        submit_btn = board_array[cell_position] == 'BF' ? bomb : board_array[cell_position]
+        cell_class ='cell-submit'
+        cell_class += ' active' if cell.status == 'revealed'
+        form_class = 'guessed' if board_array[cell_position] == 'BF'
+        form_status = cell.status == 'revealed'
+        [cell_position, submit_btn, cell_class, form_status, form_class]
       end
     end
   end

--- a/app/controllers/site_controller.rb
+++ b/app/controllers/site_controller.rb
@@ -8,7 +8,7 @@ class SiteController < ApplicationController
     ui = create_interface
     @header = display_header(ui)
     positions = game.board_positions.map{ |el| el.content }
-    @positions_to_string = positions.join(',')
+    @positions_to_string = positions.join(',').tr('B', '8')
     @rowsize = game.row_size
     @board = build_board_view(game, @rowsize)
     @positions_to_reveal = ''
@@ -16,7 +16,7 @@ class SiteController < ApplicationController
   end
 
   def update
-    game_positions = params[:positions].split(',')
+    game_positions = params[:positions].tr('8', 'B').split(',')
     @rowsize = params[:rowsize].to_i
     user_move = params[:index].to_i
     content = params[:content]
@@ -26,12 +26,9 @@ class SiteController < ApplicationController
     ui = create_interface
     board_config(game, game_positions)
     update_revealed_status(game, revealed_positions)
+    update_flag_status(game, flag_positions)
     move = convert_params_to_move(user_move, content, @rowsize)
     game.place_move(move)
-    logger.debug '*******'
-    logger.debug game.bomb_positions
-    logger.debug '*******'
-    update_flag_status(game, flag_positions)
     game.game_over = true if game.is_won?
 
     if game.game_over
@@ -49,7 +46,7 @@ class SiteController < ApplicationController
       @board = build_board_view(game, @rowsize, nil)
       @disable_submit = false
     end
-    @positions_to_string = game.board_values.join(',')
+    @positions_to_string = game.board_values.join(',').tr('B', '8')
     @positions_to_reveal = find_revealed(game.board_positions).join(',')
     @flags = find_flags(game.board_positions).join(',')
     render :home

--- a/app/views/site/home.html.erb
+++ b/app/views/site/home.html.erb
@@ -6,7 +6,7 @@
       <% @board.each.with_index do |row, i| %>
         <div class="row">
         <% row.each.with_index do |cell, j| %>
-          <div class='cell <%= "cell_#{i*@rowsize + j}" %>'>
+          <div class='cell <%= "cell_#{i*@rowsize + j} #{cell[4]}" %>'>
             <%= form_with url: site_home_path do |f|%>
             <%= f.hidden_field :content, value: cell[1] %>
             <%= f.hidden_field :index, value: cell[0] %>
@@ -14,7 +14,8 @@
             <%= f.hidden_field :rowsize, value: @rowsize %>
             <%= f.hidden_field :revealed, value: @positions_to_reveal %>
             <%= f.hidden_field :flags, value: @flags %>
-            <%= f.submit cell[2], name: 'btnSubmit', class: cell[3], id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: cell[4] || @disable_submit%>
+            <%= f.submit cell[1], name: 'btnSubmit', class: cell[2], id: "submit_#{i*@rowsize + j}", data: { disable_with: false }, disabled: cell[3] || @disable_submit%>
+            <div></div>
             <% end %>
           </div><!-- end cell -->
         <% end %>

--- a/spec/concerns/site_controller_helper_spec.rb
+++ b/spec/concerns/site_controller_helper_spec.rb
@@ -35,24 +35,12 @@ RSpec.describe SiteController, type: :controller do
 
     expect(game.board_values).to eq(expected_array)
   end
-  
+
   it 'can set the boards bomb positions' do
     positions = 'B,1, , ,0,0,1,2,B,1,2,2,0,0,0,0'.split(",")
     SiteController.board_config(game, positions)
 
     expect(game.bomb_positions).to match_array([0,8])
-  end
-
-  it 'can update the board with a move' do
-    SiteController.update_board_with_move(game, 13)
-
-    expect(game.board_positions[13].status).to eq('revealed')
-  end
-
-  it 'can update the board with a flag' do
-    SiteController.update_board_with_flag(game, 20)
-
-    expect(game.board_positions[20].flag).to eq('F')
   end
 
   it 'can build an array for the board view' do
@@ -61,7 +49,7 @@ RSpec.describe SiteController, type: :controller do
     result = SiteController.build_board_view(game, game.row_size)
 
 
-    expected_array = [0,'  ', '  ', 'cell-submit', false]
+    expected_array = [0, '  ', 'cell-submit', false, nil]
     assert_equal(result[0][0], expected_array)
   end
 
@@ -154,5 +142,18 @@ RSpec.describe SiteController, type: :controller do
     bomb_positions = bomb_positions_in_string(cells_array)
 
     expect(game.board_positions[bomb_positions.first].status).to eq('revealed')
+  end
+
+  it 'can return a bomb emoji and a guessed-bomb class for each correctly-placed flag if the game is lost' do
+    cells_array = 'B,1,1,1,1,1,1,1,B,1,0,0,2,2,2,0,0,1,B,1,0,0,1,1,1'.split(",")
+    game = create_game(5,0)
+    board_config(game, cells_array)
+    to_flag = '0,8'
+    update_flag_status(game, to_flag)
+    update_bombs_to_revealed(game)
+    result = build_board_view(game, 5, 'show')
+
+    expect(result[1][3][1]).to eq("\u{1f4a3}")
+    expect(result[1][3][4]).to eq('guessed')
   end
 end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -72,13 +72,16 @@ RSpec.describe SiteController, type: :controller do
 
     params4 = { 'content': 'F', 'index': '1', 'rowsize'=>'4', 'positions': 'BF,1, , ,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '1'}
+    params5 = { 'content': 'F', 'index': '3', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, '}
 
     params6 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,19,20,21,22,24', 'flags': '0,8,18,23'}
 
     params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '10,11,12'}
 
-    params8 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '0,1,8,18,23', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '10,11,12'}
+    params8 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '0,8,18,23', 'positions': 'B,B,1, , , , , ,B, , , , , , , , , ,B, , , , ,B, ',
+    'revealed': '10,11,12'}
+
+    params9 = { 'content': 'F', 'index': '3', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed':'3'}
 
     let (:game) {SiteController.create_game(5,5)}
 
@@ -94,20 +97,20 @@ RSpec.describe SiteController, type: :controller do
 
     it 'marks the move if position is not a bomb' do
       post :update, params: params2
-      array = [11, '0 ', '0 ', 'cell-submit active', true]
+      array = [11, '0 ', 'cell-submit active', true, nil]
       expect(assigns(:board)[2][3]).to eq(array)
     end
 
     it 'marks the move if position is not a bomb v2' do
       post :update, params: params2
 
-      expect(assigns(:positions_to_string)).to eq('B,1,0,0,2,2,0,0,B,1,0,0,1,1,0,0')
+      expect(assigns(:positions_to_string)).to eq('8,1,0,0,2,2,0,0,8,1,0,0,1,1,0,0')
     end
 
     it 'shows the bombs if move is a bomb' do
       post :update, params: params3
 
-      cell_array = [0, "\u{1f4a3}", "\u{1f4a3}", 'cell-submit active', true]
+      cell_array = [0, "\u{1f4a3}", 'cell-submit active', true, nil]
       expect(assigns(:board)[0][0]).to eq(cell_array)
     end
 
@@ -119,15 +122,21 @@ RSpec.describe SiteController, type: :controller do
 
     it 'can post a flag as a move' do
       post :update, params: params4
-      cell_array = [1, "\u{1f6a9}", "\u{1f6a9}", 'cell-submit', false]
+      cell_array = [1, "\u{1f6a9}", 'cell-submit', false, nil]
 
       expect(assigns(:board)[0][1]).to eq(cell_array)
     end
 
-    it 'does not mark the position with a flag if position is revealed' do
+    it 'marks the position with a flag if position is not revealed' do
       post :update, params: params5
-      cell_array = [ 1, '  ', '  ', 'cell-submit active', true]
-      expect(assigns(:board)[0][1]).to eq(cell_array)
+      cell_array = [3, "\u{1f6a9}", 'cell-submit', false, nil]
+      expect(assigns(:board)[0][3]).to eq(cell_array)
+    end
+
+    it 'does not mark the position with a flag if position is revealed' do
+      post :update, params: params9
+      cell_array = [3, '1 ', 'cell-submit active', true, nil]
+      expect(assigns(:board)[0][3]).to eq(cell_array)
     end
 
     it 'can check if the game is won' do
@@ -139,7 +148,7 @@ RSpec.describe SiteController, type: :controller do
     it 'can update the revealed positions' do
       post :update, params: params6
 
-      expect(assigns(:board)[2][0][3]).to include('active')
+      expect(assigns(:board)[2][0][2]).to include('active')
     end
 
     it 'can send the revealed positions to the board' do
@@ -152,6 +161,12 @@ RSpec.describe SiteController, type: :controller do
       post :update, params: params6
 
       expect(assigns(:positions_to_reveal)).to include('18')
+    end
+
+    it 'can check if the game is over' do
+      post :update, params: params8
+
+      expect(assigns(:header)).to eq('Game over! You win!')
     end
   end
 end

--- a/spec/controllers/site_controller_spec.rb
+++ b/spec/controllers/site_controller_spec.rb
@@ -70,13 +70,15 @@ RSpec.describe SiteController, type: :controller do
 
     params3 = { 'content': 'B', 'index': '0', 'rowsize'=>'4', 'positions': 'B,1, , ,0,0,1,2,B,1,2,2,0,0,0,0', 'revealed': '0'}
 
-    params4 = { 'content': 'F', 'index': '1', 'rowsize'=>'4', 'positions': 'BF,1,X,X,0,0,1,2,B,1,2,2,0,0,0,0'}
+    params4 = { 'content': 'F', 'index': '1', 'rowsize'=>'4', 'positions': 'BF,1, , ,0,0,1,2,B,1,2,2,0,0,0,0'}
 
-    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'BF,B, , , , , , ,BF, , , , , , , , , ,BF, , , , ,BF, ', 'revealed': '1'}
+    params5 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '1'}
 
     params6 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '2,3,4,5,6,7,9,10,11,12,13,14,15,16,17,19,20,21,22,24', 'flags': '0,8,18,23'}
 
-    params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B, , , , , , ,BF, , , , , , , , , ,BF, , , , ,BF, ', 'revealed': '10,11,12'}
+    params7 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '1,2,3', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '10,11,12'}
+
+    params8 = { 'content': 'F', 'index': '1', 'rowsize'=>'5', 'flags': '0,1,8,18,23', 'positions': 'B,B, , , , , , ,B, , , , , , , , , ,B, , , , ,B, ', 'revealed': '10,11,12'}
 
     let (:game) {SiteController.create_game(5,5)}
 


### PR DESCRIPTION
When a user adds a flag to the board
It should prevent the square from being revealed and/or disabled. Flood fill should not fill it.

At the end of the game,
If a flag is a correctly marked bomb then mark it with a red X
If it is not correctly marked leave it as an 'unrevealed' flag